### PR TITLE
Remove React Native language from Challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://avatars1.githubusercontent.com/u/7063040?v=4&s=200.jpg" alt="HU" width="24" /> Desafio Alpha
 
-Crie um aplicativo para dispositivo móvel (**Swift**, **Kotlin**, **React Native**, **Flutter**) que consuma o JSON exposto pela API de busca e apresente as informações em uma listagem. Você é livre para utiliar bibliotecas de terceiros.
+Crie um aplicativo para dispositivo móvel (**Swift**, **Kotlin**, **Flutter**) que consuma o JSON exposto pela API de busca e apresente as informações em uma listagem. Você é livre para utiliar bibliotecas de terceiros.
 
 **Atenção**: a apresentação em forma de listagem é apenas o requisito mínimo do desafio. Sinta-se livre para construir a sua solução. Exemplo: implementação de uma barra de busca com sugestões, detalhes de um certo produto, etc.
 


### PR DESCRIPTION
### OBJETIVO 
>Remover react native para fazer o desafio mobile.

### PORQUE
>Já rolou umas conversas sobre isso no início das contratações, sobre removermos o `React-Native` como uma das linguagens pra esse desafio (pra nossa equipe dos apps ele não faz muito sentido).
Recebemos 2 desafios nele e não temos hoje ninguém no time para fazer a validação deles.